### PR TITLE
Compress saturation data, update extended metadata

### DIFF
--- a/+lumofile/read_lufr.m
+++ b/+lumofile/read_lufr.m
@@ -719,7 +719,7 @@ if isempty(layout_override)
       'lack layout information, and it will not be possible to convert this file to '...
       'formats which require a layout. Specify an appropriate layout file to supress '... 
       'this warning.']);
-    
+      
 else
   
   % The user has supplied a layout file
@@ -745,6 +745,8 @@ end
 
 if isfield(enum.groups(gidx + 1), 'layout')
   lumomat.validate_layout(enum);
+else
+  enum.groups(gidx + 1).layout = [];
 end
 
 % Build event output structure 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 test/samples
 test/pyutil/pytenv
 test/*.zip
+exp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
  - read LUMO files v0.5
  - add `merge_layout` function to integrate layouts into LUMO files
+ - saturation data is now chunked and compressed
+ - SNIRF extended metadata now stored in root of the file, allowing validation
 
 ## v1.0.0
 

--- a/test/test.m
+++ b/test/test.m
@@ -10,3 +10,4 @@ runtests('test_SNIRF.m')
 runtests('test_lufr.m')
 runtests('test_layout_merge.m')
 
+

--- a/test/test_layout_merge.m
+++ b/test/test_layout_merge.m
@@ -54,7 +54,14 @@ end
 
 
 %% Test 3: merge layout files
-lumofile.merge_layout(fullfile(lmpath, 'samples', 'sample_v040_no_layout.LUMO'));
+try
+  lumofile.merge_layout(fullfile(lmpath, 'samples', 'sample_v040_no_layout.LUMO'));
+  error('Merge layout should throw');
+catch e
+end
+  
+
+
 
 lumo_merged_fn = lumofile.merge_layout(fullfile(lmpath, 'samples', 'sample_v040_no_layout.LUMO'), ...
                                        'C:\Users\Sam\AppData\Local\Gowerlabs\Lumo\coordinates_268.json');


### PR DESCRIPTION
Saturation flags are stored as 4-byte integers, and have the same dimensionality as the channel data. Compression significantly reduces file sizes.

Fix #16 