### PR TITLE
Fix lf_dir in read_lumo line 132

### DIFF
--- a/+lumofile/read_lumo.m
+++ b/+lumofile/read_lumo.m
@@ -129,7 +129,7 @@ function [enum, data, events] = read_lumo(lf_dir, varargin)
 %
 
 % Normalise strings
-lf_dirs = convertStringsToChars(lf_dirs);
+lf_dir = convertStringsToChars(lf_dir);
 
 ts_load = tic;
 


### PR DESCRIPTION
The `read_lumo` function refers to an `lf_dirs` variable in line 132, however no variable exists, causing the script to crash.
This Pull Request just switches it to `lf_dir`.