### PR TITLE
Update write_NIRS.m

### DIFF
--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -229,11 +229,12 @@ if ~isempty(events)
   
   if event_filter
     
-    kl = ones(length(events),1);
+    kl = true(length(events),1);
     for i = 1:length(events)
       if(length(events(i).mark) == 1)
         kl(i) = events(i).mark ~= newline;
         kl(i) = events(i).mark ~= '$';
+         kl(i) = events(i).mark ~= char(10);
       end
     end
     events = events(kl);


### PR DESCRIPTION
Two changes were made to save the event marks and time of events into the .nirs file 1) A matrix of type logic was defined as TRUE
2) To ensure the newline character is not considered as an event, an extra comparison was also added