### PR TITLE
write_NIRS changed to include cranial landmarks

### DIFF
--- a/+lumofile/read_lufr.m
+++ b/+lumofile/read_lufr.m
@@ -798,7 +798,7 @@ end
 
 
 % Load layout or take from the user
-if isempty(layout_override) & (n_layouts == 0)
+if isempty(layout_override) && (n_layouts == 0)
   
   % The user has nor provided a layout, we must use the embedded data if it exists
   % enum.groups(gidx + 1).layout = [];

--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -210,7 +210,8 @@ for mi = 1:SD.nDets
   
 end
 
-% Add Landmarks
+% Add Landmarks to SD3D
+%
 SD3D.Landmarks = zeros(size(layout.landmarks,1),3);
 for li = 1:size(layout.landmarks,1)
     SD3D.Landmarks(li,1) = layout.landmarks(li).coords_3d.x;

--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -210,6 +210,14 @@ for mi = 1:SD.nDets
   
 end
 
+% Add Landmarks
+SD3D.Landmarks = zeros(size(layout.landmarks,1),3);
+for li = 1:size(layout.landmarks,1)
+    SD3D.Landmarks(li,1) = layout.landmarks(li).coords_3d.x;
+    SD3D.Landmarks(li,2) = layout.landmarks(li).coords_3d.y;
+    SD3D.Landmarks(li,3) = layout.landmarks(li).coords_3d.z;
+end
+
 % Build MeasList
 %
 SD.MeasList = zeros(size(glch,1), 4);

--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -213,11 +213,19 @@ end
 % Add Landmarks to SD3D
 %
 SD3D.Landmarks = zeros(size(layout.landmarks,1),3);
+SD3D.LandmarksNames = cell(1,size(layout.landmarks,1));
 for li = 1:size(layout.landmarks,1)
     SD3D.Landmarks(li,1) = layout.landmarks(li).coords_3d.x;
     SD3D.Landmarks(li,2) = layout.landmarks(li).coords_3d.y;
     SD3D.Landmarks(li,3) = layout.landmarks(li).coords_3d.z;
+    
+% Add Landmarks names
+    SD3D.LandmarksNames{li} = layout.landmarks(li).name;
+    
 end
+
+
+
 
 % Build MeasList
 %


### PR DESCRIPTION
write_NIRS was modified to include the cranial landmarks in the structure SD3D.

One minor change in read_lufr: the logical operator & was changed to && to improve performance