### PR TITLE
Filter non printable event markers

### DIFF
--- a/+lumofile/read_lufr.m
+++ b/+lumofile/read_lufr.m
@@ -860,6 +860,23 @@ else
   events = [];
 end
 
+% Filter events (remove non printable characters)
+evfilt = true(ne,1);
+for i = 1:ne
+    if(length(events(i).mark) == 1)
+        if events(i).mark < char(32)
+            evfilt(i) = false;
+        end
+    end
+end
+
+events = events(evfilt);
+
+if(sum(~evfilt) > 0)
+    fprintf('Filtering %d/%d invalid event markers from recording\n', sum(~evfilt), length(evfilt));
+end
+
+
 % Build data output structure
 data = struct('chn_dat', chdat, ...
               'chn_dt', tchdat*1e3, ...

--- a/+lumomat/ver.m
+++ b/+lumomat/ver.m
@@ -1,5 +1,6 @@
 function [ver] = ver()
 %LMVER Return the hard coded version of the package
-ver = '1.5.1';
+ver = ['1.5.1' ...
+    ''];
 end
 

--- a/+lumomat/ver.m
+++ b/+lumomat/ver.m
@@ -1,5 +1,5 @@
 function [ver] = ver()
 %LMVER Return the hard coded version of the package
-ver = '1.6.0-dev';
+ver = '1.5.1';
 end
 

--- a/+lumomat/ver.m
+++ b/+lumomat/ver.m
@@ -1,6 +1,5 @@
 function [ver] = ver()
 %LMVER Return the hard coded version of the package
-ver = ['1.5.1' ...
-    ''];
+ver = '1.5.1';
 end
 


### PR DESCRIPTION
Special ASCII codes  (< 32) are removed during load of LUFR, in line with documentation.