### PR TITLE
Fixauxnirs

### DIFF
--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -276,12 +276,10 @@ if ~isempty(events)
   end
   
 else
-  
     
   % No events recorded
-  s = zeros([size(t, 1) 1]); % Add empty stimulus matrix for compatibility with Homer2
-  CondNames = {'empty'}; % Add value to CondNames for compatibility with Homer2
-  
+  s = zeros([size(t, 1) 1]); % Add a zeros stimulus matrix for compatibility with Homer2
+  CondNames = {'empty'}; % Add element to the cell for compatibility with Homer2
 end
 
 % Sort measurement list and data by (wavelength, source, detector) and apply to data,
@@ -317,10 +315,9 @@ nirs.t = t;
 nirs.d = d;
 nirs.SD = SD;
 nirs.ml = ml;
-% Add empty auxiliary matrix for compatibility with Homer2
-nirs.aux = zeros([size(nirs.t, 1) 1]);
 nirs.s = s;
 nirs.CondNames = CondNames;
+nirs.aux = zeros([size(nirs.t, 1) 1]); % Add a zeros auxiliary matrix for compatibility with Homer2
 
 if strcmp(sdstyle, 'flat')
   nirs.SD3D = SD3D;

--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -277,10 +277,9 @@ if ~isempty(events)
   
 else
   
-  
   % No events recorded
-  s = [];
-  CondNames = {};
+  s = zeros([size(t, 1) 1]); % Add empty stimulus matrix for compatibility with Homer2
+  CondNames = {'empty'}; % Add value to CondNames for compatibility with Homer2
   
 end
 
@@ -309,6 +308,30 @@ if strcmp(sdstyle,'flat')
   SD3D.SrcPowers = SD.SrcPowers;
 end
 
+  
+for gidx = 1:ng
+    
+    auxi = 1;
+    if isfield(data(gidx), 'node_temp')
+      nirs_aux_temp = create_group(nirs_group, ['aux' num2str(auxi)]); 
+      nirs(gidx).aux(auxi).name = write_var_string(nirs_aux_temp, 'name', 'temperature');
+      nirs(gidx).aux(auxi).time = write_double(nirs_aux_temp, 'time', tt_chn);
+      nirs(gidx).aux(auxi).dataTimeSeries = write_single(nirs_aux_temp, 'dataTimeSeries',  data(gidx).node_temp.');
+      auxi = auxi+1;    
+    end
+
+end
+
+
+%%
+
+
+
+
+
+
+
+
 % A duplicate entry is specified for unknown reasons
 ml = SD.MeasList;
 
@@ -317,6 +340,8 @@ nirs.t = t;
 nirs.d = d;
 nirs.SD = SD;
 nirs.ml = ml;
+% Add empty auxiliary matrix for compatibility with Homer2
+nirs.aux = zeros(size(nirs.t, 1));
 nirs.s = s;
 nirs.CondNames = CondNames;
 

--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -276,13 +276,14 @@ if ~isempty(events)
   end
   
 else
-    
+
   % No events recorded
-  % Homer2 requires the stimulus field 's' to be the same size as the time vector 't'
-  % to load NIRS data
+  %
+  % Homer2 requires the stimulus field ('s') to match the size of the time vector ('t') 
+  % to successfully load NIRS data. Additionally, the field 'CondNames' must be assigned 
+  % a value, and its length must match the number of columns in 's'.
+  %
   s = zeros(size(t, 1), 1);
-  % CondNames must have an assigned value. The length of CondNames must be 
-  % equal to the number of columns in 's'
   CondNames = {' '}; 
 end
 

--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -279,7 +279,7 @@ else
     
   % No events recorded
   s = zeros(size(t, 1), 1); % Add a zeros stimulus matrix for compatibility with Homer2
-  CondNames = {'empty'}; % Add element to the cell for compatibility with Homer2
+  CondNames = {' '}; % Add element to the cell for compatibility with Homer2
 end
 
 % Sort measurement list and data by (wavelength, source, detector) and apply to data,

--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -281,7 +281,7 @@ else
   %
   % Homer2 requires the stimulus field ('s') to match the size of the time vector ('t') 
   % to successfully load NIRS data. Additionally, the field 'CondNames' must be assigned 
-  % a value, and its length must match the number of columns in 's'.
+  % a value, and the length of 'CondNames' must match the number of columns in 's'.
   %
   s = zeros(size(t, 1), 1);
   CondNames = {' '}; 

--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -278,10 +278,11 @@ if ~isempty(events)
 else
     
   % No events recorded
-  % Homer2 requires the stimulus field ('s') to be the same size as the time vector ('t')
+  % Homer2 requires the stimulus field 's' to be the same size as the time vector 't'
   % to load NIRS data
   s = zeros(size(t, 1), 1);
-  % Length of CondNames must be equal to the number of columns in 's'
+  % CondNames must have an assigned value. The length of CondNames must be 
+  % equal to the number of columns in 's'
   CondNames = {' '}; 
 end
 

--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -278,7 +278,7 @@ if ~isempty(events)
 else
     
   % No events recorded
-  s = zeros([size(t, 1) 1]); % Add a zeros stimulus matrix for compatibility with Homer2
+  s = zeros(size(t, 1), 1); % Add a zeros stimulus matrix for compatibility with Homer2
   CondNames = {'empty'}; % Add element to the cell for compatibility with Homer2
 end
 
@@ -317,7 +317,7 @@ nirs.SD = SD;
 nirs.ml = ml;
 nirs.s = s;
 nirs.CondNames = CondNames;
-nirs.aux = zeros([size(nirs.t, 1) 1]); % Add a zeros auxiliary matrix for compatibility with Homer2
+nirs.aux = zeros(size(nirs.t, 1), 1); % Add a zeros auxiliary matrix for compatibility with Homer2
 
 if strcmp(sdstyle, 'flat')
   nirs.SD3D = SD3D;

--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -278,8 +278,11 @@ if ~isempty(events)
 else
     
   % No events recorded
-  s = zeros(size(t, 1), 1); % Add a zeros stimulus matrix for compatibility with Homer2
-  CondNames = {' '}; % Add element to the cell for compatibility with Homer2
+  % Homer2 requires the stimulus field ('s') to be the same size as the time vector ('t')
+  % to load NIRS data
+  s = zeros(size(t, 1), 1);
+  % Length of CondNames must be equal to the number of columns in 's'
+  CondNames = {' '}; 
 end
 
 % Sort measurement list and data by (wavelength, source, detector) and apply to data,
@@ -317,7 +320,8 @@ nirs.SD = SD;
 nirs.ml = ml;
 nirs.s = s;
 nirs.CondNames = CondNames;
-nirs.aux = zeros(size(nirs.t, 1), 1); % Add a zeros auxiliary matrix for compatibility with Homer2
+% Homer2 requires an auxiliary field to be the same size as 't' to load NIRS data
+nirs.aux = zeros(size(nirs.t, 1), 1); 
 
 if strcmp(sdstyle, 'flat')
   nirs.SD3D = SD3D;

--- a/+lumofile/write_NIRS.m
+++ b/+lumofile/write_NIRS.m
@@ -235,7 +235,7 @@ SD.MeasList(:,2) = glch(:,3);           % Global detector index
 SD.MeasList(:,3) = 1;                   % Always one
 SD.MeasList(:,4) = glch(:,2);           % Global wavelength index
 
-% Build event (stimulus) maitrx
+% Build event (stimulus) matrix
 %
 % LUMO records characters and strings as event markers, which differs from the way that
 % stimuli are encoded in NIRS. There is no unambiguous mapping so we implement the approach
@@ -277,6 +277,7 @@ if ~isempty(events)
   
 else
   
+    
   % No events recorded
   s = zeros([size(t, 1) 1]); % Add empty stimulus matrix for compatibility with Homer2
   CondNames = {'empty'}; % Add value to CondNames for compatibility with Homer2
@@ -308,30 +309,6 @@ if strcmp(sdstyle,'flat')
   SD3D.SrcPowers = SD.SrcPowers;
 end
 
-  
-for gidx = 1:ng
-    
-    auxi = 1;
-    if isfield(data(gidx), 'node_temp')
-      nirs_aux_temp = create_group(nirs_group, ['aux' num2str(auxi)]); 
-      nirs(gidx).aux(auxi).name = write_var_string(nirs_aux_temp, 'name', 'temperature');
-      nirs(gidx).aux(auxi).time = write_double(nirs_aux_temp, 'time', tt_chn);
-      nirs(gidx).aux(auxi).dataTimeSeries = write_single(nirs_aux_temp, 'dataTimeSeries',  data(gidx).node_temp.');
-      auxi = auxi+1;    
-    end
-
-end
-
-
-%%
-
-
-
-
-
-
-
-
 % A duplicate entry is specified for unknown reasons
 ml = SD.MeasList;
 
@@ -341,7 +318,7 @@ nirs.d = d;
 nirs.SD = SD;
 nirs.ml = ml;
 % Add empty auxiliary matrix for compatibility with Homer2
-nirs.aux = zeros(size(nirs.t, 1));
+nirs.aux = zeros([size(nirs.t, 1) 1]);
 nirs.s = s;
 nirs.CondNames = CondNames;
 


### PR DESCRIPTION
The current version of lumomat (v1.8.0) outputs a NIRS structure which does not fully align with the Homer2's user guide ([user guide](https://www.nmr.mgh.harvard.edu/martinos/software/homer/HOMER2_UsersGuide_121129.pdf)). Currently, if event markers are missing from the _.lufr_ output file, the _write_NIRS()_ function inserts an empty array into the `s` field. Additionally, the `aux` field containing the auxiliary data is missing altogether. As a result, the converted NIRS structure is incompatible with Homer2, which, as per the user guide, requires both `aux` and `s` fields to successfully load NIRS data.

This pull request enhances the compatibility of lumomat with Homer2 by:
- replacing the empty array in `s` with a zero matrix matching the size of the time vector `t`;
- adding a temporary `aux` field into the NIRS structure, also as a zero matrix matching the size of the time vector `t`.